### PR TITLE
Fixed typo in docs

### DIFF
--- a/src/content/docs/es/guides/setup-project.mdx
+++ b/src/content/docs/es/guides/setup-project.mdx
@@ -8,7 +8,7 @@ import {
 
 ### Configuración de Typescript
  
-Para que Seyfert funcione correctamente debes actualizar tu archivo `tsconfig.json` y añadir `emitDecoratorMedatada` y `experimentalDecorators` para poder utilizar decoradores:
+Para que Seyfert funcione correctamente debes actualizar tu archivo `tsconfig.json` y añadir `emitDecoratorMetadata` y `experimentalDecorators` para poder utilizar decoradores:
 
 <Tabs>
     <TabItem label ="tsconfig.json">

--- a/src/content/docs/guides/setup-project.mdx
+++ b/src/content/docs/guides/setup-project.mdx
@@ -8,7 +8,7 @@ import {
 
 ### Typescript settings
  
-To make Seyfert work as intended you must update your `tsconfig.json` file and add `emitDecoratorMedatada` and `experimentalDecorators` to be able to use decorators:
+To make Seyfert work as intended you must update your `tsconfig.json` file and add `emitDecoratorMetadata` and `experimentalDecorators` to be able to use decorators:
 
 <Tabs>
     <TabItem label ="tsconfig.json">


### PR DESCRIPTION
Fixed typo in docs.

https://seyfert-docs.vercel.app/guides/setup-project