### PR TITLE
fix: channel id property in music section

### DIFF
--- a/src/content/docs/es/misc/music.mdx
+++ b/src/content/docs/es/misc/music.mdx
@@ -102,8 +102,8 @@ export default class PlayCommand extends Command {
 				flags: MessageFlags.Ephemeral
 			});
 
-		const botVoice = ctx.me("cache")?.voice();
-		if (botVoice && botVoice.channel_id !== voice.channel_id)
+		const botVoice = ctx.me()?.voice();
+		if (botVoice && botVoice.channelId !== voice.channelId)
 			return ctx.write({
 				content: "You need to be in the same voice channel as me.",
 				flags: MessageFlags.Ephemeral
@@ -112,7 +112,7 @@ export default class PlayCommand extends Command {
 		const player = await client.kazagumo.createPlayer({
 			guildId: guildId,
 			textId: channelId,
-			voiceId: voice.channel_id,
+			voiceId: voice.channelId,
 			volume: 100
 		});
 

--- a/src/content/docs/misc/music.mdx
+++ b/src/content/docs/misc/music.mdx
@@ -101,8 +101,8 @@ export default class PlayCommand extends Command {
 				flags: MessageFlags.Ephemeral
 			});
 
-		const botVoice = ctx.me("cache")?.voice();
-		if (botVoice && botVoice.channel_id !== voice.channel_id)
+		const botVoice = ctx.me()?.voice();
+		if (botVoice && botVoice.channelId !== voice.channelId)
 			return ctx.write({
 				content: "You need to be in the same voice channel as me.",
 				flags: MessageFlags.Ephemeral
@@ -111,7 +111,7 @@ export default class PlayCommand extends Command {
 		const player = await client.kazagumo.createPlayer({
 			guildId: guildId,
 			textId: channelId,
-			voiceId: voice.channel_id,
+			voiceId: voice.channelId,
 			volume: 100
 		});
 


### PR DESCRIPTION
Due to recent VoiceState changes, the voice channel id property is now `channelId` and not `channel_id` as it was previously.
The `"cache"` was also removed from `ctx.me()` because it still returns the cache, becomes unnecessary.