### PR TITLE
docs(example): seifato

### DIFF
--- a/src/components/github/repositories-cards.astro
+++ b/src/components/github/repositories-cards.astro
@@ -3,7 +3,7 @@ const links = [
   'https://api.github.com/repos/FabrizioCoder/LuxannaRewrite',
   'https://api.github.com/repos/OpenWaifu-Project/HirakuShinzou',
   'https://api.github.com/repos/Ganyu-Studios/stelle-music',
-  'https://api.github.com/repos/KonkonBot/Konkon',
+  'https://api.github.com/repos/KonkonBot/Seifato',
 ];
 const datas = await Promise.all(
   links.map(async (link) => {


### PR DESCRIPTION
**Konkon** was now renamed to **Seifato**