### PR TITLE
Fixed typos in middlewares code blocks

### DIFF
--- a/src/content/docs/commands/middlewares.md
+++ b/src/content/docs/commands/middlewares.md
@@ -152,7 +152,7 @@ interface LoggerData {
 
 export const loggerMiddleware = createMiddleware<LoggerData>((middle) => {
     // Log the command
-    console.log(`${middle.context.author.username} (${middle.context.author.id}) ran /(${middle.context.resolver.fullCommandName}`);
+    console.log(`${middle.context.author.username} (${middle.context.author.id}) ran /${middle.context.resolver.fullCommandName}`);
 
     // Pass the data to the command
     middle.next({ time: Date.now() });
@@ -194,7 +194,7 @@ Global middlewares follow the same rule and structure explained above, with the 
 ```ts
 import { type ParseGlobalMiddlewares, Client } from 'seyfert';
 import { middlewares } from "./path/to/middlewares";
-import { global } from "./path/to/globas";
+import { global } from "./path/to/globals";
 
 const globalMiddlewares: (keyof typeof global)[] = ['logger']
 


### PR DESCRIPTION
As title, I considered amending the code blocks further to improve the code blocks further (adding missing imports to make them complete examples, changing the `console.log` to `middle.context.client.logger.info`, adding insert context to relevant lines) but I'm unsure if it's preferred to have these as separate PRs or as one single one (and I don't have the time/energy to do them atm anyway)

Perhaps once this has been merged I'll come back and do those, but for the moment this is my offering.